### PR TITLE
Fix "Object of class Closure could not be converted to string" error

### DIFF
--- a/src/Models/Route.php
+++ b/src/Models/Route.php
@@ -145,7 +145,10 @@ class Route implements Arrayable
             $middlewares = array_merge($middlewares, $this->route->{$method}());
         }
 
-        return array_filter(array_values($middlewares), fn ($mw) => is_string($mw));
+        return Arr::of($middlewares)
+            ->map(fn (mixed $middleware) => is_callable($middleware) ? 'closure' : $middleware)
+            ->values()
+            ->toArray();
     }
 
     public function getSummary(): ?string
@@ -206,6 +209,6 @@ class Route implements Arrayable
 
     protected function hasMiddleware(array $middlewares): bool
     {
-        return !empty(array_intersect($middlewares, $this->getMiddlewares()));
+        return ! empty(array_intersect($middlewares, $this->getMiddlewares()));
     }
 }

--- a/src/Models/Route.php
+++ b/src/Models/Route.php
@@ -145,7 +145,7 @@ class Route implements Arrayable
             $middlewares = array_merge($middlewares, $this->route->{$method}());
         }
 
-        return array_values($middlewares);
+        return array_filter(array_values($middlewares), fn ($mw) => is_string($mw));
     }
 
     public function getSummary(): ?string
@@ -206,6 +206,6 @@ class Route implements Arrayable
 
     protected function hasMiddleware(array $middlewares): bool
     {
-        return ! empty(array_intersect($middlewares, $this->getMiddlewares()));
+        return !empty(array_intersect($middlewares, $this->getMiddlewares()));
     }
 }


### PR DESCRIPTION
Hi, I am using the pretty-routes package and I am getting "Object of class Closure could not be converted to string" errors after adding **inline custom middleware**.

This is my base controller class and it has an inline middleware example.

```php
class MyBaseController extends BaseController
{
    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;

    public function __construct()
    {
        $this->middleware(function ($request, $next) {
            // ... my code ...

            return $next($request);
        });
    }
    
    ....
```
Then I get "Object of class Closure could not be converted to string" error in UI.

![image](https://user-images.githubusercontent.com/17010054/181519529-44df266f-7cb4-4024-bbe4-385e90c694ad.png)

When I investigated this error I realized all middlewares are not a string.

![image](https://user-images.githubusercontent.com/17010054/181520979-ee9e66b2-2890-4d35-b57a-4cecc8c5a37d.png)

So I applied to filter for only string results with **array_filter**. I am not sure about the side effects of this suggestion but it's solved my problem.

